### PR TITLE
Add ETCD_UNSUPPORTED_ARCH environment variable

### DIFF
--- a/Dockerfile.etcd
+++ b/Dockerfile.etcd
@@ -16,6 +16,7 @@ FROM hypriot/rpi-golang
 RUN mkdir -p /go/src/app
 RUN mkdir -p /var/lib/etcd
 WORKDIR /go/src/app
+ENV ETCD_UNSUPPORTED_ARCH="arm"
 
 # this will ideally be built by the ONBUILD below ;)
 CMD ["go-wrapper", "run"]


### PR DESCRIPTION
Added the ETCD_UNSUPPORTED_ARCH environment variable so that the etcd container will run.  Without this was getting an error in the etcd container log:
{"log":"2016-04-16 21:35:35.095147 E | etcdmain: etcd on unsupported platform without ETCD_UNSUPPORTED_ARCH=arm set.\n","stream":"stderr","time":"2016-04-16T21:35:35.101447739Z"}
